### PR TITLE
setup.py now installs MySQL-python as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-import PySQLPool
+
+__version__ = '0.4'
+__author__ = 'Nick Verbeck'
+__author_email__ = 'nerdynick@gmail.com'
 
 setup(name='PySQLPool',
-      version=PySQLPool.__version__,
-      author=PySQLPool.__author__,
-      author_email=PySQLPool.__author_email__,
+      version=__version__,
+      author=__author__,
+      author_email=__author_email__,
       license='LGPL V3',
       platforms=['ALL'],
       description='Python MySQL Connection Pooling and MySQL Query management',
@@ -18,7 +21,8 @@ setup(name='PySQLPool',
                      'Programming Language :: Python',
                      'Operating System :: OS Independent',
                      'Development Status :: 5 - Production/Stable'],
-      requires=['MySQL-python'],
+      install_requires=['MySQL_python'],
       provides=['pysqlpool','PySQLPool'],
-      packages=['PySQLPool']
+      packages=['PySQLPool'],
+      package_dir={'PySQLPool': 'src/PySQLPool'}
      )

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+sed -e "s#^__version__ = .*#__version__ = '$1'#" -i src/PySQLPool/__init__.py setup.py


### PR DESCRIPTION
setup.py no longer imports PySQLPool which imports MySQLdb.
This allows running setup.py even if MySQLdb is not installed on the system.

For convenience, I added the update_version.sh script, if we ever need to bump the version and are too lazy to update 2 places :)

Also, pip seems to complain when requirements contain a dash.
Replacing it with an underscore fixes that.
